### PR TITLE
Adiciona campos para histórico de transferência

### DIFF
--- a/ieducar/Assets/Javascripts/SchoolHistory.js
+++ b/ieducar/Assets/Javascripts/SchoolHistory.js
@@ -9,6 +9,9 @@ $j("#ano_fim").closest('tr').hide();
 $j("#cursoaluno").closest('tr').hide();
 $j("#apenas_ultimo_registro").closest('tr').hide();
 
+$j("#ano_transferencia").closest('tr').hide();
+$j("#cursos_transferencia").closest('tr').hide();
+
 $j("#imprime_diretor_secretario").on('click', function(){
 	if($j('#imprime_diretor_secretario').prop('checked')){
 		$j("#nm_secretario").closest('tr').show();
@@ -67,6 +70,14 @@ $j("#modelo").on('click', function(){
         $j("#ano_fim").closest('tr').hide();
         $j("#apenas_ultimo_registro").closest('tr').hide();
         $j("#cursoaluno").closest('tr').hide();
+    }
+
+    if (template == 5) {
+      $j("#ano_transferencia").closest('tr').show();
+      $j("#cursos_transferencia").closest('tr').show();
+    } else {
+        $j("#ano_transferencia").closest('tr').hide();
+        $j("#cursos_transferencia").closest('tr').hide();
     }
 });
 

--- a/ieducar/Assets/Javascripts/SchoolHistory.js
+++ b/ieducar/Assets/Javascripts/SchoolHistory.js
@@ -72,7 +72,7 @@ $j("#modelo").on('click', function(){
         $j("#cursoaluno").closest('tr').hide();
     }
 
-    if (template == 5) {
+    if (template == 5 || template == 4 || template == 3) {
       $j("#ano_transferencia").closest('tr').show();
       $j("#cursos_transferencia").closest('tr').show();
     } else {

--- a/ieducar/ReportSources/school-history-crosstab.jrxml
+++ b/ieducar/ReportSources/school-history-crosstab.jrxml
@@ -130,6 +130,8 @@
 		<defaultValueExpression><![CDATA[0]]></defaultValueExpression>
 	</parameter>
 	<parameter name="logo" class="java.lang.String"/>
+    <parameter name="ano_transferencia" class="java.lang.Integer"/>
+    <parameter name="cursos_transferencia" class="java.lang.String"/>
 	<parameter name="ano_ini" class="java.lang.Integer">
 		<defaultValueExpression><![CDATA[0]]></defaultValueExpression>
 	</parameter>

--- a/ieducar/ReportSources/school-history-early-years.jrxml
+++ b/ieducar/ReportSources/school-history-early-years.jrxml
@@ -46,6 +46,8 @@
 	<parameter name="emitir_carga_horaria_frequentada" class="java.lang.Boolean">
 		<defaultValueExpression><![CDATA[false]]></defaultValueExpression>
 	</parameter>
+    <parameter name="ano_transferencia" class="java.lang.Integer"/>
+    <parameter name="cursos_transferencia" class="java.lang.String"/>
 	<parameter name="ano_fim" class="java.lang.Integer">
 		<defaultValueExpression><![CDATA[0]]></defaultValueExpression>
 	</parameter>

--- a/ieducar/ReportSources/school-history-eja.jrxml
+++ b/ieducar/ReportSources/school-history-eja.jrxml
@@ -87,6 +87,8 @@
 	<parameter name="emitir_carga_horaria_frequentada" class="java.lang.Boolean">
 		<defaultValueExpression><![CDATA[false]]></defaultValueExpression>
 	</parameter>
+    <parameter name="ano_transferencia" class="java.lang.Integer"/>
+    <parameter name="cursos_transferencia" class="java.lang.String"/>
 	<parameter name="ano_fim" class="java.lang.Integer">
 		<defaultValueExpression><![CDATA[0]]></defaultValueExpression>
 	</parameter>

--- a/ieducar/ReportSources/school-history-nine-years.jrxml
+++ b/ieducar/ReportSources/school-history-nine-years.jrxml
@@ -43,6 +43,8 @@
 	<parameter name="diretor" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
+    <parameter name="ano_transferencia" class="java.lang.Integer"/>
+    <parameter name="cursos_transferencia" class="java.lang.String"/>
 	<parameter name="ano" class="java.lang.Integer">
 		<defaultValueExpression><![CDATA[0]]></defaultValueExpression>
 	</parameter>

--- a/ieducar/ReportSources/school-history-series-years.jrxml
+++ b/ieducar/ReportSources/school-history-series-years.jrxml
@@ -47,6 +47,8 @@
 	<parameter name="serie" class="java.lang.Integer"/>
 	<parameter name="turma" class="java.lang.Integer"/>
 	<parameter name="ano" class="java.lang.Integer"/>
+	<parameter name="ano_transferencia" class="java.lang.Integer"/>
+    <parameter name="cursos_transferencia" class="java.lang.String"/>
 	<parameter name="ano_ini" class="java.lang.Integer"/>
 	<parameter name="ano_fim" class="java.lang.Integer"/>
 	<parameter name="sequencial" class="java.lang.Integer"/>

--- a/ieducar/Views/SchoolHistoryController.php
+++ b/ieducar/Views/SchoolHistoryController.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Models\LegacyCourse;
+
 class SchoolHistoryController extends Portabilis_Controller_ReportCoreController
 {
     /**
@@ -62,6 +64,27 @@ class SchoolHistoryController extends Portabilis_Controller_ReportCoreController
         ];
         $options = ['label' => 'Modelo', 'resources' => $resources, 'value' => 1];
         $this->inputsHelper()->select('modelo', $options);
+        $this->inputsHelper()->integer('ano_transferencia', [
+            'placeholder' => '',
+            'label_hint' => 'Ano da matrícula de transferência para boletim anexado ao histórico. Caso não preenchido será pego o último ano de histórico gerado.',
+            'required' => false,
+            'label' => 'Ano da transferência',
+            'max_length' => 4,
+            'size' => 4
+        ]);
+
+        $cursos = LegacyCourse::all()->pluck('nm_curso','cod_curso')->toArray();
+        $helperOptions = ['objectName' => 'cursos_transferencia'];
+        $options = [
+            'label' => 'Cursos',
+            'label_hint' => 'Cursos considerados para buscar boletim de transferência anexado ao histórico.',
+            'size' => 50,
+            'required' => false,
+            'options' => [
+                'all_values' => $cursos,
+            ],
+        ];
+        $this->inputsHelper()->multipleSearchCustom(attrName: '', inputOptions: $options, helperOptions: $helperOptions);
 
         $this->inputsHelper()->integer('ano_ini', ['placeholder' => '', 'required' => false, 'label' => 'Ano início', 'max_length' => 4, 'size' => 4]);
         $this->inputsHelper()->integer('ano_fim', ['placeholder' => '','required' => false, 'label' => 'Ano final', 'max_length' => 4, 'size' => 4]);
@@ -95,6 +118,9 @@ class SchoolHistoryController extends Portabilis_Controller_ReportCoreController
         $this->report->addArg('turma', (int) $this->getRequest()->ref_cod_turma);
         $this->report->addArg('ano', (int) $this->getRequest()->ano);
         $this->report->addArg('emitir_carga_horaria_frequentada', (bool) $this->getRequest()->emitir_carga_horaria_frequentada);
+        $this->report->addArg('ano_transferencia', ($this->getRequest()->ano_transferencia == '' ? 0 : (int)$this->getRequest()->ano_transferencia));
+        $curstoTransferencia = implode(',', array_filter($this->getRequest()->cursos_transferencia ?? []));
+        $this->report->addArg('cursos_transferencia', trim($curstoTransferencia) == '' ? 0 : $curstoTransferencia);
         $this->report->addArg('ano_ini', ($this->getRequest()->ano_ini == '' ? 0 : (int)$this->getRequest()->ano_ini));
         $this->report->addArg('ano_fim', ($this->getRequest()->ano_fim == '' ? 0 : (int)$this->getRequest()->ano_fim));
         $cursoaluno = implode(',', array_filter($this->getRequest()->cursoaluno ?? []));


### PR DESCRIPTION
### Descrição
Adiciona campos de **"Ano de transferência"** e **"Cursos"** para servirem de apoio na emissão do boletim de transferência anexado ao histórico escolar.

Os campos são apresentados apenas quando selecionado o modelo **"9 anos"** no formulário de emissão.

-----

### Screenshot

![image](https://github.com/loginx-tech/i-educar-reports-package/assets/5911217/1ac8b583-38e8-4021-9024-996754d60336)
